### PR TITLE
add check for existing crow.dfu file

### DIFF
--- a/fledge.lua
+++ b/fledge.lua
@@ -21,7 +21,10 @@ function ver(result)
 	url = result:match("h.*")
 	url = url:sub(1,-2)
 	notify("> downloading firmware")
-  	local cmd = "sudo wget -T 180 -q -P /home/we/dust/code/fledge/ " .. url
+	if util.file_exists('/home/we/dust/code/fledge/crow.dfu') then
+	  norns.system_cmd('rm -rf /home/we/dust/code/fledge/crow.dfu')
+	end
+  local cmd = "sudo wget -T 180 -q -P /home/we/dust/code/fledge/ " .. url
 	print(cmd)
 	norns.system_cmd(cmd, flash)
 end
@@ -55,6 +58,3 @@ function key(n,z)
 		go()
 	end
 end
-
-
-


### PR DESCRIPTION
currently, if fledge has downloaded the `crow.dfu` file once already, it will download a fresh copy as `crow.dfu 2`, incrementing with each initiation.

this PR checks if a `crow.dfu` file already exists in the script's folder -- if it does, it's removed before downloading a fresh copy. i did try some invocations of `-O` to force overwrites, but couldn't grok the required invocation so i went with a brute-force method :)